### PR TITLE
Add relative velocity and acceleration

### DIFF
--- a/msg/ObjectKinematics.msg
+++ b/msg/ObjectKinematics.msg
@@ -1,4 +1,6 @@
 geometry_msgs/Pose pose
 geometry_msgs/Twist velocity
+geometry_msgs/Twist rel_velocity
 geometry_msgs/Accel accel
+geometry_msgs/Accel rel_accel
 geometry_msgs/Vector3 dimensions

--- a/msg/ObjectKinematics.msg
+++ b/msg/ObjectKinematics.msg
@@ -1,6 +1,6 @@
 geometry_msgs/Pose pose
-geometry_msgs/Twist velocity
+geometry_msgs/Twist abs_velocity
 geometry_msgs/Twist rel_velocity
-geometry_msgs/Accel accel
+geometry_msgs/Accel abs_accel
 geometry_msgs/Accel rel_accel
 geometry_msgs/Vector3 dimensions


### PR DESCRIPTION
Added fields for relative velocity and acceleration. Should I also change names of old fields to indicate absolute velocity? I.e `velocity` to `abs_velocity` and `accel` to `abs_accel`.